### PR TITLE
fix: import blob

### DIFF
--- a/game/server/koa-router.ts
+++ b/game/server/koa-router.ts
@@ -7,6 +7,7 @@ import { setHttpCallback } from '@citizenfx/http-wrapper';
 
 import FormData from 'form-data';
 import fetch from 'node-fetch';
+import { Blob } from 'node:buffer';
 import { CaptureOptions, DataType } from './types';
 import { UploadStore } from './upload-store';
 


### PR DESCRIPTION
Blob is not imported, which causes it to error out while using `base64`. This resolves that issue, tested it locally.