### PR TITLE
fix(client): NUI upload/stream via resource https URLs (DDoS/WAF safe path)

### DIFF
--- a/game/client/bootstrap.ts
+++ b/game/client/bootstrap.ts
@@ -1,4 +1,3 @@
-import { request } from 'http';
 import { netEventController } from './event';
 import { CaptureRequest, RequestScreenshotUploadCB, ScreenshotCreatedBody } from './types';
 import { exportHandler, uuidv4 } from './utils';
@@ -15,7 +14,7 @@ onNet('screencapture:captureScreen', (token: string, options: object, dataType: 
     uploadToken: token,
     dataType,
     action: 'capture',
-    serverEndpoint: `http://${GetCurrentServerEndpoint()}/${GetCurrentResourceName()}/upload`,
+    serverEndpoint: `https://${GetCurrentResourceName()}/upload`,
   });
 });
 
@@ -139,7 +138,7 @@ function createImageCaptureMessage(options: CaptureRequest) {
   SendNUIMessage({
     ...options,
     action: 'capture',
-    serverEndpoint: `http://${GetCurrentServerEndpoint()}/${GetCurrentResourceName()}/upload`,
+    serverEndpoint: `https://${GetCurrentResourceName()}/upload`,
   });
 }
 
@@ -148,7 +147,7 @@ onNet("screencapture:captureStream", (token: string, options: object) => {
     ...options,
     uploadToken: token,
     action: 'capture-stream-start',
-    serverEndpoint: `http://${GetCurrentServerEndpoint()}/${GetCurrentResourceName()}/stream`,
+    serverEndpoint: `https://${GetCurrentResourceName()}/stream`,
   });
 })
 


### PR DESCRIPTION
Fixes uploads breaking when the server is behind VibeGames style DDoS protection: NUI no longer POSTs to http://GetCurrentServerEndpoint/..., it uses https://<resource>/upload and /stream instead.